### PR TITLE
Feature configparser

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - beautifulsoup4
   - boto3
   - botocore
+  - ConfigArgParse
   - django
   - django-environ
   - django-extensions

--- a/environment.yml
+++ b/environment.yml
@@ -48,4 +48,5 @@ dependencies:
 
   - pip:
     - wikipedia-api
+    - fuzzywuzzy
     # - nlpia

--- a/nlpia_bot/clibot.py
+++ b/nlpia_bot/clibot.py
@@ -205,9 +205,9 @@ def parse_args(args):
         type=str,
         metavar="STR")
     parser.add_argument(
-        '--name',
-        default=DEFAULT_CONFIG['name'],
-        dest="nickname",
+        '--num_top_replies',
+        default=DEFAULT_CONFIG['num_top_replies'],
+        dest="num_top_replies",
         help="Limit on the number of top (high score) replies that are randomly selected from.",
         type=int,
         metavar="INT")

--- a/nlpia_bot/clibot.py
+++ b/nlpia_bot/clibot.py
@@ -132,6 +132,7 @@ class CLIBot:
     """ Conversation manager intended to interact with the user on the command line, but can be used by other plugins/
 
     >>> CLIBot(bots='parul,pattern'.split(','), num_top_replies=1).reply('Hi')
+    'Hello!'
     """
     bot_names = []
     bot_modules = []

--- a/nlpia_bot/clibot.py
+++ b/nlpia_bot/clibot.py
@@ -208,6 +208,7 @@ def parse_args(args):
         type=str,
         metavar="STR")
     parser.add_argument(
+        '-n',
         '--num_top_replies',
         default=DEFAULT_CONFIG['num_top_replies'],
         dest="num_top_replies",

--- a/nlpia_bot/clibot.py
+++ b/nlpia_bot/clibot.py
@@ -83,7 +83,7 @@ def normalize_replies(replies=''):
 class CLIBot:
     """ Conversation manager intended to interact with the user on the command line, but can be used by other plugins/
 
-    >>> CLIBot(bots='parul,pattern', num_top_replies=1).reply('Hello world')
+    >>> CLIBot(bots='parul,pattern'.split(','), num_top_replies=1).reply('Hi')
     """
     bot_names = []
     bot_modules = []

--- a/nlpia_bot/clibot.py
+++ b/nlpia_bot/clibot.py
@@ -73,6 +73,7 @@ def normalize_replies(replies=''):
         replies = [(1e-10, replies)]
     elif isinstance(replies, tuple) and len(replies, 2) and isinstance(replies[0], float):
         replies = [(replies[0], str(replies[1]))]
+    # TODO: this sorting is likely unnecessary, redundant with sort happening within CLIBot.reply()
     return sorted([
         ((1e-10, r) if isinstance(r, str) else tuple(r))
         for r in replies
@@ -141,8 +142,10 @@ class CLIBot:
             bot_replies = normalize_replies(bot_replies)
             replies.extend(bot_replies)
         if len(replies):
-            log.info(f'Found {len(replies)} suitable replies...')
+            log.info(f'Found {len(replies)} suitable replies, limiting to {self.num_top_replies}...')
             replies = self.quality_score.update_replies(replies, statement)
+            # re-sorts the replies based on their updated scores
+            replies = sorted(replies, reverse=True)[:self.num_top_replies]
             cumsum = 0
             cdf = list()
             for reply in replies:

--- a/nlpia_bot/clibot.py
+++ b/nlpia_bot/clibot.py
@@ -14,6 +14,54 @@ Besides console scripts, the header (i.e. until _logger...) of this file can
 also be used as template for Python modules.
 
 Note: This skeleton file can be safely removed if not needed!
+
+```bash
+$ bot -b 'pattern,parul' -vv -p --num_top_replies=1
+2019-12-09:20:21:46.404 WARNING  [spacy_language_model.py:14] Failed to import spaCyHunSpell. Substituting with fake . . .
+2019-12-09:20:21:46.404 WARNING  [spacy_language_model.py:42] Loading SpaCy model...
+2019-12-09:20:21:47.142 INFO     [clibot.py:285] Building a BOT with: ['pattern', 'parul']
+2019-12-09:20:21:47.142 INFO     [clibot.py:109] Adding bot named pattern_bots
+2019-12-09:20:21:47.143 INFO     [clibot.py:116] Adding a Bot class <class 'nlpia_bot.skills.pattern_bots.Bot'>
+from module <module 'nlpia_bot.skills.pattern_bots' from '/Users/hobs/code/chatbot/nlpia-bot/nlpia_bot/skills/pattern_bots.py'>...
+2019-12-09:20:21:47.143 INFO     [clibot.py:109] Adding bot named parul_bots
+2019-12-09:20:21:50.911 INFO     [clibot.py:116] Adding a Bot class <class 'nlpia_bot.skills.parul_bots.Bot'>
+from module <module 'nlpia_bot.skills.parul_bots' from '/Users/hobs/code/chatbot/nlpia-bot/nlpia_bot/skills/parul_bots.py'>...
+2019-12-09:20:21:50.923 WARNING  [clibot.py:290] Type "quit" or "exit" to end the conversation...
+YOU: Hello someone not a chatbot.
+2019-12-09:20:22:55.741 INFO     [clibot.py:305] Computing a reply to Hello someone not a chatbot....
+2019-12-09:20:22:55.741 INFO     [clibot.py:126] statement=Hello someone not a chatbot.
+2019-12-09:20:22:55.748 INFO     [clibot.py:145] Found 4 suitable replies, limiting to 1...
+{'replies': [(0.2, "Hey. That's a good one."), (0.1, 'Hello'), (0.05, 'Wuh?'),
+(0.4588375897316045, 'hello barbie is an internet-connected version of the doll that uses a chatbot provided by the company toytalk,
+which previously used the chatbot for a range of smartphone-based characters for children.')],
+'self': <nlpia_bot.scores.quality_score.QualityScore object at 0x117c6b290>, 'stmt': 'Hello someone not a chatbot.'}
+bot: hello barbie is an internet-connected version of the doll that uses a chatbot provided by the company toytalk, which previously
+ used the chatbot for a range of smartphone-based characters for children.
+YOU: Hello another chatbot.
+2019-12-09:20:23:14.798 INFO     [clibot.py:305] Computing a reply to Hello another chatbot....
+2019-12-09:20:23:14.799 INFO     [clibot.py:126] statement=Hello another chatbot.
+2019-12-09:20:23:14.804 INFO     [clibot.py:145] Found 4 suitable replies, limiting to 1...
+{'replies': [(0.2, "Hey. That's a good one."), (0.1, 'Hello'), (0.05, 'Wuh?'),
+(0.4588375897316045, 'hello barbie is an internet-connected version of the doll that uses a chatbot provided by the company toytalk,
+which previously used the chatbot for a range of smartphone-based characters for children.')],
+'self': <nlpia_bot.scores.quality_score.QualityScore object at 0x117c6b290>, 'stmt': 'Hello another chatbot.'}
+bot: hello barbie is an internet-connected version of the doll that uses a chatbot provided by the company toytalk,
+which previously used the chatbot for a range of smartphone-based characters for children.
+YOU: Hi
+2019-12-09:20:23:21.182 INFO     [clibot.py:305] Computing a reply to Hi...
+2019-12-09:20:23:21.182 INFO     [clibot.py:126] statement=Hi
+2019-12-09:20:23:21.187 INFO     [clibot.py:145] Found 2 suitable replies, limiting to 1...
+{'replies': [(1.0, 'Hello!'), (1e-10, "I am sorry! I don't understand you")],
+'self': <nlpia_bot.scores.quality_score.QualityScore object at 0x117c6b290>, 'stmt': 'Hi'}
+bot: Hello!
+YOU: Looking good!
+2019-12-09:20:23:33.617 INFO     [clibot.py:305] Computing a reply to Looking good!...
+2019-12-09:20:23:33.617 INFO     [clibot.py:126] statement=Looking good!
+2019-12-09:20:23:33.622 INFO     [clibot.py:145] Found 2 suitable replies, limiting to 1...
+{'replies': [(0.05, 'Wuh?'), (0.31232662648349846, 'the internet) retrieving information about goods and services.')],
+'self': <nlpia_bot.scores.quality_score.QualityScore object at 0x117c6b290>, 'stmt': 'Looking good!'}
+bot: the internet) retrieving information about goods and services.
+```
 """
 import collections.abc
 import importlib

--- a/nlpia_bot/constants.py
+++ b/nlpia_bot/constants.py
@@ -20,6 +20,7 @@ os.makedirs(LOG_DIR, exist_ok=True)
 LOG_LEVELS = [logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR, logging.FATAL]
 LOG_LEVEL_NAMES = 'DEBUG INFO WARNING ERROR FATAL'.split()
 LOG_LEVEL_ABBREVIATIONS = [s[:4].lower() for s in LOG_LEVEL_NAMES]
+LOG_LEVEL_ABBR_DICT = dict(zip(LOG_LEVEL_ABBREVIATIONS, LOG_LEVELS))
 
 logging.basicConfig(
     format='%(asctime)s.%(msecs)d %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s',

--- a/nlpia_bot/scores/quality_score.py
+++ b/nlpia_bot/scores/quality_score.py
@@ -1,21 +1,13 @@
 import logging
 import nltk
-import sys
 import importlib
 
 from nltk.sentiment.vader import SentimentIntensityAnalyzer
 
-from nlpia_bot.constants import passthroughSpaCyPipe
 from nlpia_bot import spacy_language_model
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.INFO)
-
-try:
-    from spacy_hunspell import spaCyHunSpell
-except ImportError:
-    log.warn('Failed to import spaCyHunSpell. Substituting with fake . . .')
-    spaCyHunSpell = passthroughSpaCyPipe
 
 
 class QualityScore:
@@ -24,18 +16,6 @@ class QualityScore:
         self.modules = {metric: importlib.import_module(f'nlpia_bot.scores.{metric}_score') for metric in metrics}
         self.weights = weights if weights is not None else [1.0] * len(metrics)
         self.nlp = spacy_language_model.nlp
-        if sys.platform == 'linux' or sys.platform == 'linux2':
-            hunspell = spaCyHunSpell(self.nlp, 'linux')
-        elif sys.platform == 'darwin':
-            hunspell = spaCyHunSpell(self.nlp, 'mac')
-        else:  # sys.platform == 'win32':
-            try:
-                # TODO determine paths for en_US.dic and en_US.aff on windows
-                hunspell = spaCyHunSpell(self.nlp, ('en_US.dic', 'en_US.aff'))
-            except Exception:
-                log.warn('Failed to locate en_US.dic and en_US.aff files. Substituting with fake . . .')
-                hunspell = passthroughSpaCyPipe()
-        self.nlp.add_pipe(hunspell)
         try:
             self.sentiment_analyzer = SentimentIntensityAnalyzer()
         except LookupError:

--- a/nlpia_bot/scores/quality_score.py
+++ b/nlpia_bot/scores/quality_score.py
@@ -24,7 +24,7 @@ class QualityScore:
         self.kwargs = {'nlp': self.nlp, 'sentiment_analyzer': self.sentiment_analyzer}
 
     def update_replies(self, replies, stmt=None):
-        print(locals())
+        log.debug(replies)
         metrics_scores = [[reply[0] for reply in replies]]
         for i in range(len(self.metrics)):
             metric = self.metrics[i]

--- a/nlpia_bot/skills/parul_bots.py
+++ b/nlpia_bot/skills/parul_bots.py
@@ -56,7 +56,7 @@ def greeting(sentence):
             return random.choice(GREETING_RESPONSES)
 
 
-# Generating response
+# Generating scored responses
 def response(user_text):
     user_text = [user_text] if isinstance(user_text, str) else user_text
     robo_response = ''
@@ -68,11 +68,11 @@ def response(user_text):
     flat.sort()
     req_tfidf = flat[-1]
     if(req_tfidf == 0):
-        robo_response = robo_response + "I am sorry! I don't understand you"
+        robo_response = "I am sorry! I don't understand you"
         return robo_response
     else:
-        robo_response = robo_response + WIKI_SENTENCES[idx]
-        return robo_response
+        robo_response = WIKI_SENTENCES[idx]
+        return [(flat[-1], robo_response)]
 
 
 def main():
@@ -90,7 +90,7 @@ def main():
                     print("ROBO: " + greeting(user_text))
                 else:
                     print("ROBO: ", end="")
-                    print(response(user_text))
+                    print(sorted(response(user_text))[-1][1])
                     # sent_tokens.remove(user_text)
         else:
             flag = False
@@ -106,11 +106,7 @@ class Bot:
         >>> len(respond('Hey Mycroft!'))
         4
         """
-        responses = []
-        bot_statement = response(statement.lower())
-        responses.append((1.0, bot_statement))
-
-        return responses
+        return response(statement.lower())
 
 
 if __name__ == '__main__':

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ setup_requires = pyscaffold>=3.1a0,<3.2a0
 install_requires =
     boto3
     ConfigArgParse
+    fuzzywuzzy
     gitpython
     # hunspell
     # jupyter

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ package_dir =
 setup_requires = pyscaffold>=3.1a0,<3.2a0
 install_requires =
     boto3
+    ConfigArgParse
     gitpython
     # hunspell
     # jupyter

--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -1,7 +1,9 @@
 # test_doctests
 import pytest  # noqa
 import doctest
+
 import nlpia_bot.skills.eliza_bots
+import nlpia_bot.clibot
 
 __author__ = "SEE AUTHORS.md"
 __copyright__ = "Hobson Lane"
@@ -10,6 +12,13 @@ __license__ = "The Hippocratic License, see LICENSE.txt (MIT + Do no Harm)"
 
 def test_eliza_bots():
     results = doctest.testmod(nlpia_bot.skills.eliza_bots, optionflags=doctest.ELLIPSIS |
+                              doctest.NORMALIZE_WHITESPACE, verbose=True)
+    assert results.failed < 1
+    assert results.attempted > 0
+
+
+def test_clibot():
+    results = doctest.testmod(nlpia_bot.clibot, optionflags=doctest.ELLIPSIS |
                               doctest.NORMALIZE_WHITESPACE, verbose=True)
     assert results.failed < 1
     assert results.attempted > 0


### PR DESCRIPTION
- in parul (wiki search) scored replies using TFIDF similarity
- moved hunspell to spacy_language_model
- added clibot doctest
- resorted scored replies after quality_score updating
- add config parser (untested)
- add `--num_top_replies=1` or `-n 1` for deterministic bot (no dice rolling)
- remove print statement in quality_score (replace with log.debug)