### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -31,10 +31,10 @@ dependencies:
     - editdistance==0.5.3
     - elasticsearch==7.6.0
     - environment==1.0.0
-    - fuzzywuzzy==0.18.0
     - gitpython==3.1.1
     - nltk==3.5
     - python-slugify==4.0.0
+    - rapidfuzz==0.9.1
     - scikit-learn==0.22.2
     - tensorboardX==2.0
     - tensorflow==2.2.0

--- a/qary/skills/search_fuzzy_bots.py
+++ b/qary/skills/search_fuzzy_bots.py
@@ -5,7 +5,7 @@ import os
 
 import yaml
 import pandas as pd
-from fuzzywuzzy import process
+from rapidfuzz import process
 from ..constants import DATA_DIR
 
 log = logging.getLogger(__name__)
@@ -83,7 +83,7 @@ class Bot:
         return db
 
     def reply(self, statement, db=None):
-        """ Use fuzzywuzzy to find the closest key in the dictionary then return the value for that key
+        """ Use rapidfuzz to find the closest key in the dictionary then return the value for that key
 
         >>> bot = MovieBot()
         >>> reply = bot.reply

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -30,7 +30,6 @@ docutils==0.15.2
 editdistance==0.5.3
 elasticsearch==7.6.0
 environment==1.0.0
-fuzzywuzzy==0.18.0
 gitpython==3.1.1
 lxml==4.5.0
 nltk==3.5
@@ -38,6 +37,7 @@ pandas==1.0.3
 pre_commit==2.3.0
 python-slugify==4.0.0
 # psycopg2==2.8.5
+rapidfuzz==0.9.1
 regex==2020.4.4
 seaborn==0.10.0
 spacy==2.2.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,6 @@ install_requires =
     editdistance==0.5.3
     elasticsearch==7.6.0
     environment==1.0.0
-    fuzzywuzzy==0.18.0
     gitpython==3.1.1
     lxml==4.5.0
     nltk==3.5
@@ -72,6 +71,7 @@ install_requires =
     pre_commit==2.3.0
     python-slugify==4.0.0
     # psycopg2==2.8.5
+    rapidfuzz==0.9.1
     regex==2020.4.4
     seaborn==0.10.0
     spacy==2.2.4


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy